### PR TITLE
docs(readme): fix npm badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cloud Health
 <p align=center>
 <a href='http://CloudNativeJS.io/'><img src='https://img.shields.io/badge/homepage-CloudNativeJS-blue.svg'></a>
-<a href='https://www.npmjs.org/package/@cloudnative/health'><img src='https://img.shields.io/badge/npm-v2.1.0-blue' alt='npm'/>
+<a href='https://www.npmjs.org/package/@cloudnative/health'><img src='https://img.shields.io/npm/v/@cloudnative/health' alt='npm'/></a>
 <a href="http://travis-ci.org/CloudNativeJS/cloud-health"><img src="https://secure.travis-ci.org/CloudNativeJS/cloud-health.svg?branch=master" alt="Build status"></a>
 <a href='https://coveralls.io/github/CloudNativeJS/cloud-health?branch=master'><img src='https://coveralls.io/repos/github/CloudNativeJS/cloud-health/badge.svg?branch=master' alt='Coverage Status' /></a>
 <a href='https://greenkeeper.io/'><img src='https://badges.greenkeeper.io/CloudNativeJS/cloud-health.svg' alt='Greenkeeper' /></a>


### PR DESCRIPTION
Update image URL to a non-static one and add missing `</a>` tag.